### PR TITLE
Forcing https in production environment

### DIFF
--- a/UnoCPI/settings.py
+++ b/UnoCPI/settings.py
@@ -60,6 +60,11 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
+MIDDLEWARE_CLASSES = (
+    # Force user to https on Heroku; must be first in list of classes
+    'sslify.middleware.SSLifyMiddleware',
+)
+
 ROOT_URLCONF = 'UnoCPI.urls'
 
 TEMPLATES = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ Shapely==1.6.4.post1
 six==1.11.0
 urllib3==1.24.1
 whitenoise==3.3.1
+django-sslify>=0.2.0


### PR DESCRIPTION
This change will force https in production on Heroku. Heroku natively provides https/SSL. This change adds django-sslify, which adds a simple setting to force https redirects: https://github.com/rdegges/django-sslify. 



