### PR TITLE
559 - Address reordering to Organization Profile and Organization Update Pages

### DIFF
--- a/partners/forms.py
+++ b/partners/forms.py
@@ -83,8 +83,8 @@ class CommunityPartnerForm(forms.ModelForm):
     community_type = forms.ModelChoiceField(queryset=CommunityType.objects, label='Community Type',empty_label='Select Community Type')
     class Meta:
         model = CommunityPartner
-        fields = ('name', 'website_url', 'community_type', 'k12_level', 'address_line1', 'address_line2', 'country','county',
-                  'city', 'state', 'zip')
+        fields = ('name', 'website_url', 'community_type', 'k12_level', 'address_line1', 'city','state',
+                   'zip','county','country')
         labels = {
 
             'website_url': ('Website'),

--- a/partners/templates/partners/community_partner_org_profile.html
+++ b/partners/templates/partners/community_partner_org_profile.html
@@ -114,24 +114,12 @@ font-variant: normal;
           <div class="col-md-7">
             <label> {{community_partner.name}} </label>
           </div>
-          <div class="col-md-5 text-right">
-            <label>Address Line 1 : </label>
-          </div>
-          <div class="col-md-7">
-            <label> {{community_partner.address_line1}} </label>
-          </div>
-          <div class="col-md-5 text-right">
-            <label>Address Line 2 : </label>
-          </div>
-          <div class="col-md-7">
-            <label>{{community_partner.address_line2}} </label>
-          </div>
-          <div class="col-md-5 text-right">
+         <div class="col-md-5 text-right">
             <label>Website URL : </label>
           </div>
           <div class="col-md-7">
             <label> {{community_partner.website_url}} </label>
-          </div>  
+          </div>
           <div class="col-md-5 text-right">
             <label> CEC Partner : </label>
           </div>
@@ -153,6 +141,12 @@ font-variant: normal;
           </div>
           {% endif %}
           <div class="col-md-5 text-right">
+            <label>Address Line 1 : </label>
+          </div>
+          <div class="col-md-7">
+            <label> {{community_partner.address_line1}} </label>
+          </div>
+          <div class="col-md-5 text-right">
             <label> City : </label>
           </div>
           <div class="col-md-7">
@@ -164,17 +158,17 @@ font-variant: normal;
           <div class="col-md-7">
             <label> {{community_partner.state}} </label>
           </div>
+         <div class="col-md-5 text-right">
+            <label> Zip : </label>
+          </div>
+          <div class="col-md-7">
+            <label> {{community_partner.zip}} </label>
+          </div>
           <div class="col-md-5 text-right">
             <label> Country : </label>
           </div>
           <div class="col-md-7">
             <label> {{community_partner.country}} </label>
-          </div>
-          <div class="col-md-5 text-right">
-            <label> Zip : </label>
-          </div>
-          <div class="col-md-7">
-            <label> {{community_partner.zip}} </label>
           </div>
         </div>
 


### PR DESCRIPTION
#559  The community Partner pages for Organization Profile and Organization Update needed reordering as well-

* Please find changes in the Organization Profile -
![image](https://user-images.githubusercontent.com/26983295/52171900-dbb9b000-272a-11e9-9ab2-7f1176669bae.png)

* Organization Update Page-
![image](https://user-images.githubusercontent.com/26983295/52171906-f3913400-272a-11e9-8b58-d29a85346bc3.png)
