### PR TITLE
Changing label from Search for Existing Projects to All Projects

### DIFF
--- a/projects/templates/projects/SearchProject.html
+++ b/projects/templates/projects/SearchProject.html
@@ -53,7 +53,7 @@ label, .btn-default
         <div class="row justify-content-md-center">
 		    <div class="col-lg-12 col-md-12">
                 <div class = "panel panel-default">
-                    <div class="panel-heading text-center"><h4>Search for Existing Projects</h4></div>&emsp;
+                    <div class="panel-heading text-center"><h4>All Projects</h4></div>&emsp;
 			            <div class="panel-body">
 
                          <!--/div>


### PR DESCRIPTION
Fixing label on "All Projects" drop-down page: 

![image](https://user-images.githubusercontent.com/41122083/52186641-53044800-27ee-11e9-92b4-626a8dea9588.png)
