### PR TITLE
606-Campus partner organization page fix

### DIFF
--- a/partners/templates/partners/campus_partner_org_profile.html
+++ b/partners/templates/partners/campus_partner_org_profile.html
@@ -1,147 +1,109 @@
 {% extends 'home/Campus_Home.html' %}
 {% load bootstrap %}
-{% block content %}
+{% block content %}{% load staticfiles %}
 
-<style>
+    <style>
 
-.btn-custom
-{
-margin-left: -200px;
-}
-
- h4
-{
-    line-height: 2.7;
-    font-size: 1.3em;
-}
-
- label
-{
-    margin-left: 25px;
-    margin-top: 5px;
-    font-weight: bold;
-}
+        label, .btn-default
+        {
+            margin-left:100px;
+        }
 
 
- img.center
-{
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
-}
 
- address
-{
-    font-variant-caps: small-caps;
-}
- a
-{
-    font-variant: normal;
-}
-</style>
+        /* Datatable Css */
 
-{% if messages %}
-    <ul class="messages">
-    {% for message in messages %}
-        <li class="{{ message.tags }}">{{ message }}</li>
-    {% endfor %}
-  </ul>
-{% endif %}
+        .btn-group{float:left;, labels:"Export"}
+        #example_length{float:left; margin:0 0 0 0px;}
+        #example_length select{width:50%;}
 
-<div class = "container">
-    <div class ="row justify-content-md-center">
-        <div class="col-xl-8 col-md-10 col-sm-10">
-            <div class = "panel panel-default">
-                <div class="panel-heading text-center"><h4><b>Organization Profile</b></h4></div>
-                <div class="panel-body">
-                  <div class="col-md-6">
-                      <h4>Organization Details</h4>
-                  </div>
-                  <div class="row">
-                      <div class="col-md-5 text-right">
-                          <label>Organization Name : </label>
-                      </div>
-                      <div class="col-md-7">
-                          <label> {{campus_partner.name}} </label>
-                      </div>
-          <!-- <div class="col-md-5 text-right">
-            <label>Education System : </label>
-          </div>
-          <div class="col-md-7">
-            <label> {{campus_partner.education_system}} </label>
-          </div>
-          <div class="col-md-5 text-right">
-            <label>University : </label>
-          </div>
-          <div class="col-md-7">
-            <label>{{campus_partner.university}} </label>
-          </div> -->
-                      <div class="col-md-5 text-right">
-                          <label>College Name : </label>
-                      </div>
-                      <div class="col-md-7">
-                          <label> {{campus_partner.college_name}} </label>
-                      </div>
-                      <div class="col-md-5 text-right">
-                          <label> Department : </label>
-                      </div>
-                      <div class="col-md-7">
-                          <label> {{campus_partner.department}} </label>
-                      </div>
-                  </div>
-              <div class="col-md-6">
-                  <h4>Contact Details</h4>
-              </div>
-              <div class="row">
-                  {% for contact in contacts %}
-                      <div class="col-md-3 text-right">
-                          <label> First Name : </label>
-                      </div>
-                      <div class="col-md-3">
-                          <label> {{contact.first_name}} </label>
-                      </div>
-                      <div class="col-md-3 text-right">
-                          <label> Last Name : </label>
-                      </div>
-                      <div class="col-md-3">
-                          <label> {{contact.last_name}} </label>
-                      </div>
-                      <div class="col-md-3 text-right">
-                          <label> Work Phone : </label>
-                      </div>
-                      <div class="col-md-3">
-                          <label> {{contact.work_phone}} </label>
-                      </div>
-                      <div class="col-md-3 text-right">
-                          <label> Cell Phone : </label>
-                      </div>
-                      <div class="col-md-3">
-                          <label> {{contact.cell_phone}} </label>
-                      </div>
-                      <div class="col-md-3 text-right">
-                          <label> Email : </label>
-                      </div>
-                      <div class="col-md-3">
-                          <label> {{contact.email_id}} </label>
-                      </div>
-                      <div class="col-md-3 text-right">
-                          <label> Contact Type : </label>
-                      </div>
-                      <div class="col-md-3">
-                          <label> {{contact.contact_type}} </label>
-                      </div>
-                      {% endfor %}
-                  </div>
-              </div>
-              <div class="text-center">
-                  <a href="{% url 'partners:orgprofileupdate' %}" class="btn btn-custom" role="button" style = "background-color: #b8b8b8"> Edit </a>
-          <!-- <a href="#" class="btn btn-default" role="button" style = "background-color: #b8b8b8"> Edit </a> -->
-              </div>
-        <br><br>
-          </div>
-      </div>
-  </div>
-</div>
 
-<br><br><br>
+        div.dataTables_wrapper div.dataTables_length label
+        {
+            margin-left:0px;
+        }
+
+
+        div.dataTables_wrapper div.dataTables_filter label
+        {
+            float:right;
+        }
+
+
+        @media (max-width: 900px)
+        {
+            div.dataTables_wrapper div.dataTables_length label
+            {
+                float:left;
+                margin-left:50px;
+            }
+            #example_length select{width:35%;}
+        }
+
+        div.dataTables_wrapper div.dataTables_paginate
+        {
+            float:right;
+        }
+    th{
+        text-align: center;
+    }
+
+
+
+    </style>
+
+    {% if messages %}
+        <ul class="messages">
+            {% for message in messages %}
+                <li class="{{ message.tags }}">{{ message }}</li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+
+
+    <div class = "container-fluid">
+        <div class="row justify-content-md-center">
+            <div class="col-lg-12 col-md-12">
+                <div class = "panel panel-default">
+                    <div class="panel-heading text-center"><h4>Organization Details</h4></div>&emsp;
+                    <div class="panel-body">
+                        <div class="container">
+                            <table id="example" class="table table-striped table-bordered dt-responsive overflow-wrap:break-word" style="width:100%">
+                                <thead>
+                                <tr>
+                                    <th>Organization Name</th>
+                                    <th>College Name</th>
+                                    <th>Department</th>
+                                    <th>Contact Name</th>
+                                    <th>Work Phone</th>
+                                    <th>Cell Phone</th>
+                                    <th>Email</th>
+                                </tr>
+                                </thead>
+                                {% for campus_partner,contacts in final%}
+                                    <tr>
+                                        <td>{{campus_partner.name}}</td>
+                                        <td>{{campus_partner.college_name}}</td>
+                                        <td>{{campus_partner.department}}</td>
+                                        <td>{{contacts.first_name}}&nbsp;&nbsp;{{contacts.last_name}}</td>
+                                        <td>{{contacts.work_phone}}</td>
+                                        <td>{{contacts.cell_phone}}</td>
+                                        <td>{{contacts.email_id}} </td>
+                                    </tr>
+                                {% endfor %}
+                            </table>
+                        </div>
+                    </div>
+                    <div style="margin-left: 400px; padding: 50px">
+                        <a href="#" class="btn btn-custom" role="button" style = "background-color: #b8b8b8"> Add </a>
+                        <a href="{% url 'partners:orgprofileupdate' %}" class="btn btn-custom" role="button" style = "background-color: #b8b8b8"> Edit </a>
+                        <a href="#" class="btn btn-custom" role="button" style = "background-color: #b8b8b8"> Delete </a>
+                    </div>
+                    <br><br>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <br><br><br>
 {% endblock %}

--- a/partners/views.py
+++ b/partners/views.py
@@ -262,13 +262,19 @@ def orgProfile(request):
                            })
 
     elif request.user.is_campuspartner:
-        campus_user = get_object_or_404(CampusPartnerUser, user=request.user.id)
-        campus_partner = get_object_or_404(CampusPartner, name=campus_user.campus_partner)
-        contacts = Contact.objects.filter(campus_partner= campus_partner.id)
+        campus_user = CampusPartnerUser.objects.filter(user=request.user.id)
+        campus_partner=[]
+        contacts=[]
+        for user in campus_user:
+            campus_partner1 = CampusPartner.objects.filter(name= user.campus_partner)
+            for partner in campus_partner1:
+                contacts1 = Contact.objects.filter(campus_partner=partner)
 
-        return render(request, 'partners/campus_partner_org_profile.html', {"contacts":contacts,
-                               "campus_partner": campus_partner
-                           })
+            campus_partner.extend(campus_partner1)
+            contacts.extend(contacts1)
+            #to combine the two list into a single list
+            final = zip(campus_partner,contacts)
+        return render(request, 'partners/campus_partner_org_profile.html', {"final":final})
 
 
 # Campus and Community Partner org Update Profile


### PR DESCRIPTION
#606 
The organization page for a campus partner user was throwing an error if there were more than 1 campus partner associated for the user. 

The organization page is enhanced to display a table instead of blocks displayed earlier.

![image](https://user-images.githubusercontent.com/26983338/52228665-8a1f3b80-2878-11e9-9542-4a1d0e276873.png)
