### PR TITLE
Update requirement.txt to fix django-import-export

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ django-bootstrap-form==3.4
 django-discover-runner==1.0
 django-filter==2.0.0
 django-filters==0.2.1
-django-import-export==1.2.0
+git+git://github.com/django-import-export/django-import-export@Master#egg=django-import-export
 django-parsley==0.7
 django-role-permissions==2.2.0
 django-storages==1.7.1


### PR DESCRIPTION
Fixing issue where xlsx doesn't work due to tablib being outdated in package. 