### PR TITLE
Create project form - Error is handled

### DIFF
--- a/projects/templates/projects/projectadd.html
+++ b/projects/templates/projects/projectadd.html
@@ -115,17 +115,18 @@
                                                 {{form2|bootstrap}}
                                             </div>
                                         </div>
-                                            <div class="input-group-append" >
-                                                <button class="btn btn-secondary add-community-row">Add an Additional Community Partner</button>
-                                            </div>
-
+{#                                            <div class="input-group-append" >#}
+{#                                                <button class="btn btn-secondary add-community-row">Add an Additional Community Partner</button>#}
+{#                                            </div>#}
+                                        <p class = h9>  If you have additional Community Partners, you can update them while editing your Project details!</p>
+                                        <p id="errorid1"></p>
                                     </div>
                                 {%endfor%}
 
                                 {% for form3 in formset3 %}
                                     <div class="campus-row" id="contact1" style="margin-top:20px;">
                                         <div class="col-lg-12">
-                                            <h6>Campus Partner Information{% for data_definition in data_definition %}{% if data_definition.id == 1%}<span tabindex="-1" data-toggle="popover" data-trigger="focus" data-content="{{ data_definition.description }}" class="float"><i class="fa fa-info-circle fa-align-top" aria-hidden="true"></i></span>
+                                            <h6>Campus Partner Information {% for data_definition in data_definition %}{% if data_definition.id == 1%}<span tabindex="-1" data-toggle="popover" data-trigger="focus" data-content="{{ data_definition.description }}" class="float"><i class="fa fa-info-circle fa-align-top" aria-hidden="true"></i></span>
                                                 {% endif %} {% endfor %}
                                             </h6><br>
                                         </div>
@@ -137,7 +138,7 @@
 {#                                        <div class="input-group-append" >#}
 {#                                            <button class="btn btn-secondary add-campus-row">Add an Additional Campus Partner</button>#}
 {#                                        </div>#}
-                                        <p class = h9>If you have additional Campus Partners, you can update them while editing your Project details!</p>
+                                        <p class = h9>  If you have additional Campus Partners, you can update them while editing your Project details!</p>
                                     <p id="errorid1"></p>
                                     </div>
 
@@ -147,11 +148,11 @@
 
                                 <div class="col-lg-12">
                                     <p class = h9>Couldn't find your Campus Partner or Community Partner? Please Register your Partner before creating a New Project.</p>
-                                    <a class="btn btn-link" href="/partners/registerCampusPartnerForProject"
+                                    <a class="btn btn-link" href="/partners/registerCampusPartnerForProject"  style="color: #d71920;"
                                        onclick="return confirm('You will be redirected to page where you can register your partner. ' +
                                                                 'Upon Submission of the registration form, you will be redirected back to this page to create a new project.'+
                                                                 ' Are you sure you want to register a New Campus Partner?')">Register a New Campus Partner</a>
-                                    <a class="btn btn-link" href="/partners/registerCommunityPartnerForProject"
+                                    <a class="btn btn-link" href="/partners/registerCommunityPartnerForProject" style="color: #d71920;"
                                        onclick="return confirm('You will be redirected to page where you can register your partner. ' +
                                                                 'Upon Submission of the registration form, you will be redirected back to this page to create a new project.'+
                                                                 ' Are you sure you want to register a New Community Partner?')">Register a New Community Partner</a>

--- a/projects/views.py
+++ b/projects/views.py
@@ -161,10 +161,7 @@ def project_total_Add(request):
             proj = project.save()
             proj.project_name = proj.project_name + " :" + str(proj.academic_year)
             eng = str(proj.engagement_type)
-            if eng == "Service Learning":
-                course = course.save(commit=False)
-                course.project_name = proj
-                course.save()
+
             address = proj.address_line1
             if (address != "N/A"):  # check if a community partner's address is there
                 fulladdress = proj.address_line1 + ' ' + proj.city


### PR DESCRIPTION
The create Project form was erroring out when Engagement Type was SLA -

![image](https://user-images.githubusercontent.com/26983295/54962206-f5f55a80-4f31-11e9-9422-00663ace687c.png)

Now, this is being saved.

Also changed the hyperlinks of Create a new Campus Partner and Create a new Community Partner to the one requested.

![image](https://user-images.githubusercontent.com/26983295/54962321-52f11080-4f32-11e9-9381-8268167e7ecd.png)

