### PR TITLE
Formatting the infowindow on right click

### DIFF
--- a/home/static/js/communityPartner.js
+++ b/home/static/js/communityPartner.js
@@ -333,7 +333,7 @@ function attachMessage(marker, partner_name,project_number,city,miss_name, comm_
     google.maps.event.addListener(marker, 'rightclick', function() {
         infowindow.setContent(
             '<tr><td style="margin-top: 5%"><span style="font-weight:bold">Community Partner:</span>&nbsp;&nbsp; </td><td>' + partner_name + '</td></tr><br />' +
-            '<tr><td style="margin-top: 5%"><span style="font-weight:bold">Projects:</span>&nbsp;&nbsp; </td><td>' + projects.toString().replace(/\s*\(.*?\)\s*/g,"<br> ")+ '</td></tr><br />')
+            '<tr><td style="margin-top: 5%"><span style="font-weight:bold">Projects:</span>&nbsp;&nbsp; </td><td>' + projects.join("<br>").replace(/\s*\(.*?\)\s*/g,"")+ '</td></tr><br />')
          // '<tr><td style="margin-top: 5%"><span style="font-weight:bold">Projects:</span>&nbsp;&nbsp; </td><td>' + projects.toString().split(",").join("<br>")+ '</td></tr><br />')
         map.panTo(this.getPosition());
 

--- a/home/static/js/communityPartnerType.js
+++ b/home/static/js/communityPartnerType.js
@@ -333,7 +333,7 @@ function attachMessage(marker, partner_name,district_number,project_number,city,
     google.maps.event.addListener(marker, 'rightclick', function() {
         infowindow.setContent(
             '<tr><td style="margin-top: 5%"><span style="font-weight:bold">Community Partner:</span>&nbsp;&nbsp; </td><td>' + partner_name + '</td></tr><br />' +
-            '<tr><td style="margin-top: 5%"><span style="font-weight:bold">Projects:</span>&nbsp;&nbsp; </td><td>' + projects.toString().replace(/\s*\(.*?\)\s*/g,"<br> ")+ '</td></tr><br />')
+            '<tr><td style="margin-top: 5%"><span style="font-weight:bold">Projects:</span>&nbsp;&nbsp; </td><td>' + projects.join("<br>").replace(/\s*\(.*?\)\s*/g,"")+ '</td></tr><br />')
          // '<tr><td style="margin-top: 5%"><span style="font-weight:bold">Projects:</span>&nbsp;&nbsp; </td><td>' + projects.toString().split(",").join("<br>")+ '</td></tr><br />')
         map.panTo(this.getPosition());
 

--- a/home/static/js/legislativeDistrict.js
+++ b/home/static/js/legislativeDistrict.js
@@ -347,8 +347,9 @@ function attachMessage(marker, partner_name,project_number,city,miss_name, comm_
     google.maps.event.addListener(marker, 'rightclick', function() {
         infowindow.setContent(
             '<tr><td style="margin-top: 5%"><span style="font-weight:bold">Community Partner:</span>&nbsp;&nbsp; </td><td>' + partner_name + '</td></tr><br />' +
-            '<tr><td style="margin-top: 5%"><span style="font-weight:bold">Projects:</span>&nbsp;&nbsp; </td><td>' + projects.toString().replace(/\s*\(.*?\)\s*/g,"<br> ")+ '</td></tr><br />')
+            // '<tr><td style="margin-top: 5%"><span style="font-weight:bold">Projects:</span>&nbsp;&nbsp; </td><td>' + projects.toString().replace(/\s*\(.*?\)(?:,)\s*/g,"<br> ")+ '</td></tr><br />')
          // '<tr><td style="margin-top: 5%"><span style="font-weight:bold">Projects:</span>&nbsp;&nbsp; </td><td>' + projects.toString().split(",").join("<br>")+ '</td></tr><br />')
+        '<tr><td style="margin-top: 5%"><span style="font-weight:bold">Projects:</span>&nbsp;&nbsp; </td><td>' + projects.join("<br>").replace(/\s*\(.*?\)\s*/g,"")+ '</td></tr><br />')
         map.panTo(this.getPosition());
 
         // google.maps.event.addListener(marker, 'rightclick', function() {


### PR DESCRIPTION
The "," separating the projects in the infowindow on right click is replaced by a " " as requested.
![image](https://user-images.githubusercontent.com/26983338/55516299-7272f200-5632-11e9-9ce4-7955621cfb36.png)
