### PR TITLE
Workflow for Inviting Community Partner User updated

### DIFF
--- a/home/templates/home/registration/communityPartnerRegistrationComplete.html
+++ b/home/templates/home/registration/communityPartnerRegistrationComplete.html
@@ -1,0 +1,59 @@
+{% extends "home/base_home.html" %}
+{% block content %}
+
+<style>
+ @media (min-width: 700px)
+{
+.panel
+{
+width: 400px;
+margin-left: auto;
+margin-right:auto;
+margin-top:150px;
+height: relative;
+}
+}
+
+
+
+@media (max-width: 700px)
+{
+h4
+{
+font-size:1.3em
+}
+}
+
+p
+{
+margin-left: 15%;
+margin-top: 5%;
+margin-right : 15%
+
+}
+.panel {
+    width: 60%;
+    margin-bottom: 30%;
+    background-color: #ffffff;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.5);
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.5);
+}
+
+</style>
+
+    <div class="container">
+        <div class = "panel panel-default">
+            <div class="panel-heading text-center"><h4>Password Updated</h4></div>
+            <div class="panel-body">
+                <p class="text-center">
+                    Your password is updated<br>
+                    You can now login to our application by clicking the button below</p>
+                    <a style="margin-left: 40%" class="btn btn btn-secondary btn-md" href={%url 'login' %} role="button"> <i class="fa fa-sign-in" aria-hidden="true"> Login</i></a>
+            </div>
+        </div>
+    </div>
+
+
+{% endblock %}

--- a/home/templates/home/registration/registerCommunityPartner.html
+++ b/home/templates/home/registration/registerCommunityPartner.html
@@ -88,7 +88,7 @@
                 <p class="text-justify" style="margin-left: 5%; margin-right: 3%">
                     <i>By submitting this form, I agree to the <a style="color: #d71920" href="https://unocpi.s3.amazonaws.com/documents/Terms_and_Conditions.pdf" target="_blank"><i>terms and conditions</i></a> of the Community Partnership Initiative.</i></p>
             </div>
-                    <a style="margin-left: 40%" class="btn btn btn-secondary btn-md" href='/password_reset/' role="button"> <i class="fa fa-key" aria-hidden="true"> Create Password</i></a>
+                    <a style="margin-left: 40%" class="btn btn btn-secondary btn-md" href={%url 'commPartnerResetPassword' pk=user.pk %} role="button"> <i class="fa fa-key" aria-hidden="true"> Create Password</i></a>
         </div>
     </div>
         </div>

--- a/home/urls.py
+++ b/home/urls.py
@@ -37,5 +37,5 @@ urlpatterns = [
    path('communityPartnerType', views.googlemapdata, name='googlemap'),
    path('activate/<str:uidb64>/<str:token>', views.activate, name='activate'),
    path('inviteCommPartner/<str:uidb64>/<str:token>', views.registerCommPartner, name='inviteCommPartner'),
-   path('inviteCommPartner/', views.commPartnerResetPassword, name='commPartnerResetPassword')
+   path('inviteCommPartner/done/<str:pk>/', views.commPartnerResetPassword, name='commPartnerResetPassword')
 ]

--- a/home/views.py
+++ b/home/views.py
@@ -1060,17 +1060,18 @@ def registerCommPartner(request, uidb64, token):
 
 
 
-def commPartnerResetPassword(request):
+def commPartnerResetPassword(request,pk):
     if request.method == 'POST':
-        form = SetPasswordForm(request.user, request.POST)
+        user_obj = User.objects.get(pk=pk)
+        form = SetPasswordForm(user_obj, request.POST)
         if form.is_valid():
             user = form.save()
             update_session_auth_hash(request, user)  # Important!
-            messages.success(request, ('Your password was successfully updated!'))
-            return redirect('/')
+            return render(request,'home/registration/communityPartnerRegistrationComplete.html')
         else:
-            messages.error(request, 'Please correct the error below.')
+            messages.error(request, 'Please correct the errors!.')
     else:
         form = SetPasswordForm(request.user)
-    return render(request, 'registration/password_reset_confirm.html', {'form': form })
-    return render(request,'home/register_done.html')
+    return render(request, 'registration/password_reset_confirm.html', {
+        'form': form,'validlink':True
+    })


### PR DESCRIPTION
Here are the changes -

1. User gets the activation link , on click of the activation link, it redirects to this screen -

![image](https://user-images.githubusercontent.com/26983295/56844505-cc07be80-6876-11e9-9098-8770642bd3b6.png)

2. On click of the "Create Password" button, the user is navigated to a form to reset the password-
![image](https://user-images.githubusercontent.com/26983295/56844511-e3df4280-6876-11e9-86aa-778f7b300d1e.png)

3. Once the user enters in the new password, user is redirected to the login screen -
![image](https://user-images.githubusercontent.com/26983295/56844523-01141100-6877-11e9-9053-6ac03245dc8c.png)
