### PR TITLE
homepage spacing and card header fixes

### DIFF
--- a/home/static/css/base_home.css
+++ b/home/static/css/base_home.css
@@ -565,7 +565,10 @@ span.outline {
 .cardhomepage {
     flex: 1 0 300px;
     box-sizing: border-box;
-    margin: 1rem .25em;
+    margin-top:0.6em;
+    margin-bottom:0.6em;
+    margin-left:0.6em;
+    margin-right:0.6em;
 }
 
 .homepage img {
@@ -768,7 +771,6 @@ span.outline {
     font-size: 1em;
     position: relative;
     text-align: center;
-    opacity: 10%;
     /*text-shadow: 0px 0px 30px rgba(0, 0, 0, 1);*/
     z-index: 1;
     padding: 0 20px;


### PR DESCRIPTION
base_home.css 

Fixed the spacing between cards and removed opacity for h3 header. Which was changing the text color.