### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ The official repository of the Community Engagement Partnership Initiative (UNO)
     •	Python Version 3.10
     •	Django Version 4.1.7
     •	PostgresSQL Version 14
+    •	Heroku Stack 20
+    
 
 
 #Getting Started:


### PR DESCRIPTION
Moving heroku stack back to 20 with this re-deploy because SAML does not work on heroku stack 22.

Heroku stack 20 is available till 2025 according to: [Heroku Stack Info](https://devcenter.heroku.com/articles/stack)

