### PR TITLE
Reports updates

### DIFF
--- a/City_GEOJSON.py
+++ b/City_GEOJSON.py
@@ -38,7 +38,7 @@ conn = psycopg2.connect(user=settings.DATABASES['default']['USER'],
                         host=settings.DATABASES['default']['HOST'],
                         port=settings.DATABASES['default']['PORT'],
                         database=settings.DATABASES['default']['NAME'],
-                        sslmode="disable")
+                        sslmode="require")
 if (conn):
     cursor = conn.cursor()
     logger.info("Connection Successful!")

--- a/Partner_GEOJSON.py
+++ b/Partner_GEOJSON.py
@@ -38,7 +38,7 @@ conn = psycopg2.connect(user=settings.DATABASES['default']['USER'],
                         host=settings.DATABASES['default']['HOST'],
                         port=settings.DATABASES['default']['PORT'],
                         database=settings.DATABASES['default']['NAME'],
-                        sslmode="disable")
+                        sslmode="require")
 if (conn):
     cursor = conn.cursor()
     logger.info("Connection Successful!")

--- a/Project_GEOJSON.py
+++ b/Project_GEOJSON.py
@@ -25,7 +25,7 @@ conn = psycopg2.connect(user=settings.DATABASES['default']['USER'],
                         host=settings.DATABASES['default']['HOST'],
                         port=settings.DATABASES['default']['PORT'],
                         database=settings.DATABASES['default']['NAME'],
-                        sslmode="disable")
+                        sslmode="require")
 
 if (conn):
     cursor = conn.cursor()

--- a/home/templates/charts/engagementtypechart2.html
+++ b/home/templates/charts/engagementtypechart2.html
@@ -301,7 +301,11 @@ $(document).ready(function(){
     <script>
         const selectEl = document.getElementById("id_academic_year");
         const options = Array.from(selectEl.options);
-        options.sort((a, b) => b.value.localeCompare(a.value));
+        options.sort((a, b) => {
+          const valueA = parseInt(a.value);
+          const valueB = parseInt(b.value);
+          return valueB - valueA;
+        });
         selectEl.innerHTML = '';
         options.forEach((option) => selectEl.add(option));
     </script>

--- a/home/templates/reports/EngagementTypeReport.html
+++ b/home/templates/reports/EngagementTypeReport.html
@@ -401,7 +401,11 @@ $(document).on('input', '.clearable', function(){
     <script>
         const selectEl = document.getElementById("id_academic_year");
         const options = Array.from(selectEl.options);
-        options.sort((a, b) => b.value.localeCompare(a.value));
+        options.sort((a, b) => {
+          const valueA = parseInt(a.value);
+          const valueB = parseInt(b.value);
+          return valueB - valueA;
+        });
         selectEl.innerHTML = '';
         options.forEach((option) => selectEl.add(option));
     </script>

--- a/home/templates/reports/ProjectPartnerInfo_admin.html
+++ b/home/templates/reports/ProjectPartnerInfo_admin.html
@@ -466,7 +466,11 @@ $(document).ready(function(){
     <script>
         const selectEl = document.getElementById("id_academic_year");
         const options = Array.from(selectEl.options);
-        options.sort((a, b) => b.value.localeCompare(a.value));
+        options.sort((a, b) => {
+          const valueA = parseInt(a.value);
+          const valueB = parseInt(b.value);
+          return valueB - valueA;
+        });
         selectEl.innerHTML = '';
         options.forEach((option) => selectEl.add(option));
     </script>

--- a/projects/templates/reports/community_private_view.html
+++ b/projects/templates/reports/community_private_view.html
@@ -229,25 +229,7 @@
                 </tr>
                 </thead>
                 <tbody>
-                {#            {% for community in community_list %}#}
-                {#            <tr>#}
-                {#                <td>{{community.community_name}}</td>#}
-                {#                <td>{% for mission in community.community_mission %}{{ mission }}<br>{% endfor %}</td>#}
-                {#                <td> {% for email in community.email %} <a href="mailto:{{email}}">{{email}}</a> <br><br> {% endfor %} </td>#}
-                {#                <td>#}
-                {#                     {% if  community.project_count  < 1 %}#}
-                {#                        {{community.project_count}}#}
-                {#                     {% else %}#}
-                {#                        <a href="{% url 'projectspublicreport' %}?proj_id_list={{ community.project_id_list }}" target="_blank" class="class1">{{ community.project_count }}</a>#}
-                {#                {% endif %}#}
-                {#                    {{community.project_count}}#}
-                {#                </td>#}
-                {#                <td>{{community.total_uno_students}}</td>#}
-                {#                <td>{{community.total_uno_hours}}</td>#}
-                {#                <td>{{community.total_economic_impact}}</td>#}
-                {#                <td><a href="{{community.website}}"  class="class1" target="_blank">{{community.website}}</a></td>#}
-                {#            </tr>#}
-                {#            {% endfor %}#}
+
                 {% for community in communityData %}
                     <tr>
                         <td>{{community.CommunityName}}</td>
@@ -425,7 +407,11 @@
       <script>
         const selectEl = document.getElementById("id_academic_year");
         const options = Array.from(selectEl.options);
-        options.sort((a, b) => b.value.localeCompare(a.value));
+         options.sort((a, b) => {
+          const valueA = parseInt(a.value);
+          const valueB = parseInt(b.value);
+          return valueB - valueA;
+        });
         selectEl.innerHTML = '';
         options.forEach((option) => selectEl.add(option));
     </script>

--- a/projects/templates/reports/community_public_view.html
+++ b/projects/templates/reports/community_public_view.html
@@ -357,7 +357,11 @@ $(document).ready(function(){
 <script>
         const selectEl = document.getElementById("id_academic_year");
         const options = Array.from(selectEl.options);
-        options.sort((a, b) => b.value.localeCompare(a.value));
+        options.sort((a, b) => {
+          const valueA = parseInt(a.value);
+          const valueB = parseInt(b.value);
+          return valueB - valueA;
+        });
         selectEl.innerHTML = '';
         options.forEach((option) => selectEl.add(option));
     </script>

--- a/projects/templates/reports/projects_private_view.html
+++ b/projects/templates/reports/projects_private_view.html
@@ -736,7 +736,11 @@
      <script>
         const selectEl = document.getElementById("id_academic_year");
         const options = Array.from(selectEl.options);
-        options.sort((a, b) => b.value.localeCompare(a.value));
+        options.sort((a, b) => {
+          const valueA = parseInt(a.value);
+          const valueB = parseInt(b.value);
+          return valueB - valueA;
+        });
         selectEl.innerHTML = '';
         options.forEach((option) => selectEl.add(option));
     </script>

--- a/projects/templates/reports/projects_public_view.html
+++ b/projects/templates/reports/projects_public_view.html
@@ -725,7 +725,11 @@
     <script>
         const selectEl = document.getElementById("id_academic_year");
         const options = Array.from(selectEl.options);
-        options.sort((a, b) => b.value.localeCompare(a.value));
+        options.sort((a, b) => {
+          const valueA = parseInt(a.value);
+          const valueB = parseInt(b.value);
+          return valueB - valueA;
+        });
         selectEl.innerHTML = '';
         options.forEach((option) => selectEl.add(option));
     </script>

--- a/projects/templates/reports/projectsprivatetableview.html
+++ b/projects/templates/reports/projectsprivatetableview.html
@@ -320,11 +320,6 @@
                             Campus Partners
                         </label>
                         <select  id="id_campus_partner" name="campus_partner" data-cy="id_campus_partner">
-                            {#                        <option> All </option>#}
-                            {##}
-                            {#                        {% for campus in campus_filter.form.campus_partner %}#}
-                            {#                            {{campus}}#}
-                            {#                        {% endfor %}#}
                             <option > All </option>
                             <option value {% if campus_id == 0 %} selected {% endif %}>---------</option>
 
@@ -383,6 +378,16 @@
                             {% endfor %}
                         </select>
                     </div>
+                    <div class="col-lg-4 col-md-5 form-group">
+                        <label for="project_name" style="padding-bottom: 0;">
+        <span tabindex="-1" data-toggle="tooltip" title="{% get_data_definition_desc 'Project Name' %}" class="float">
+            <i class="fa fa-info-circle fa-align-top" aria-hidden="true"></i>
+        </span>
+                            Project Name
+                        </label>
+                        <input type="text" id="id_project_name" name="project_name" placeholder="Enter Project Name"
+                               data-cy="project-name" style="height: 30px;margin-top: 5px;">
+                    </div>
 
 
                 </form>
@@ -395,6 +400,7 @@
         <!--<div class = "panel panel-default" style=" box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);">-->
         <!--<div class="panel-body">-->
         <div class="box" data-cy="box">
+        <div><a href="#bottom" class="scroll-to-bottom" style="color: crimson; float: right;">▼</a></div>
 
             <table id="example" class="table table-responsive table-striped table-bordered dt-responsive overflow-wrap:break-word" style="width:100%" data-cy="example">
                 <thead>
@@ -422,6 +428,18 @@
                                title="{% get_data_definition_desc 'Campus Partner' %}" class="float" >
                                             <i class="fa fa-info-circle fa-align-top" aria-hidden="true"></i></span>
                     Campus Partners
+                    </th>
+                       <th class="all">
+                        <span tabindex="-1" data-toggle="tooltip" data-placement="bottom"
+                               title="{% get_data_definition_desc 'Created At' %}" class="float" >
+                                            <i class="fa fa-info-circle fa-align-top" aria-hidden="true"></i></span>
+                    Created At
+                    </th>
+                    <th class="all">
+                        <span tabindex="-1" data-toggle="tooltip" data-placement="bottom"
+                               title="{% get_data_definition_desc 'Updated At' %}" class="float" >
+                                            <i class="fa fa-info-circle fa-align-top" aria-hidden="true"></i></span>
+                    Updated At
                     </th>
                     <th class="none">Engagement Type:</th>
                     <th class="none">Activity Type:</th>
@@ -453,6 +471,8 @@
                         <td data-cy="mission-table">{{ project.mission_area.all|join:", " }}</td>
                         <td data-cy="communityPartner-table">{{ project.community_partner.all|join:", " }}</td>
                         <td data-cy="campusPartner-table">{{ project.campus_partner.all|join:", "}}</td>
+                        <td data-cy="updatedAt-table">{{ project.updated_date}}</td>
+                        <td data-cy="createdAt-table">{{ project.created_date }}</td>
                         <td data-cy="engagementtype-table">{{ project.engagement_type}}</td>
                         <td data-cy="activityType-table">{{ project.activity_type }}</td>
                         {% if project.other_activity_type %}
@@ -519,6 +539,7 @@
 
                 &nbsp;&nbsp;&nbsp;
                     <a href="#top" class="scroll-to-top" style="color: crimson;">▲</a>
+                    <a name="bottom"></a>
 
         </div>
     </div>
@@ -737,7 +758,11 @@
      <script>
         const selectEl = document.getElementById("id_academic_year");
         const options = Array.from(selectEl.options);
-        options.sort((a, b) => b.value.localeCompare(a.value));
+        options.sort((a, b) => {
+          const valueA = parseInt(a.value);
+          const valueB = parseInt(b.value);
+          return valueB - valueA;
+        });
         selectEl.innerHTML = '';
         options.forEach((option) => selectEl.add(option));
     </script>

--- a/projects/templates/reports/projectspublictableview.html
+++ b/projects/templates/reports/projectspublictableview.html
@@ -378,6 +378,7 @@
         <!--<div class = "panel panel-default" style=" box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);">-->
         <!--<div class="panel-body">-->
         <div class="box" data-cy="box" >
+        <div><a href="#bottom" class="scroll-to-bottom" style="color: crimson; float: right;">▼</a></div>
 
             <table id="example" class="table table-responsive table-striped table-bordered dt-responsive overflow-wrap:break-word" style="width:100%" data-cy="box1">
                 <thead>
@@ -492,6 +493,7 @@
                 {% endif %}
                 &nbsp;&nbsp;&nbsp;
                     <a href="#top" class="scroll-to-top" style="color: crimson;">▲</a>
+                    <a name="bottom"></a>
         </div>
     </div>
 


### PR DESCRIPTION
It includes below changes:
1.	Academic years now appear in descending order across all reports as requested (#2673).
2.	Load reports now default to displaying data for the previous year instead of the current/latest year.
3.	Fixed the issue where community partner details were not displayed when editing a project (#2665).
4.	Included "Created At" and "Updated At" timestamps in project reports.
5.	Add a search filter for project names in the project report filters.
6.	Project reports will now load 200 records per page instead of 100 for improved search.
7.	Added an anchor to easily scroll to the bottom-right of the page.
